### PR TITLE
Remove defaults from test_env.yaml

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,7 +1,6 @@
 name: feflow-test
 channels:
   - conda-forge
-  - defaults
 dependencies:
     # Base depends
   - gufe


### PR DESCRIPTION
We don't want to pull in non-conda-forge stuff 