### PR TITLE
[WIP] Settings model with both pydantic 1 and 2 support

### DIFF
--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -7,7 +7,7 @@ energy calculations using perses.
 from typing import Optional
 from gufe.settings import Settings
 from openff.units import unit
-from pydantic import root_validator
+from pydantic.v1 import root_validator
 from openfe.protocols.openmm_utils.omm_settings import SystemSettings, SolvationSettings
 from openfe.protocols.openmm_rfe.equil_rfe_settings import AlchemicalSettings
 

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -7,7 +7,11 @@ energy calculations using perses.
 from typing import Optional
 from gufe.settings import Settings
 from openff.units import unit
-from pydantic.v1 import root_validator
+# Support for both pydantic 1 and 2
+try:
+    from pydantic.v1 import root_validator
+except ImportError:
+    from pydantic import root_validator
 from openfe.protocols.openmm_utils.omm_settings import SystemSettings, SolvationSettings
 from openfe.protocols.openmm_rfe.equil_rfe_settings import AlchemicalSettings
 


### PR DESCRIPTION
Pydantic 2 changed a significant amount of things in the validators. A quick (and dirty?) way of supporting both is using `pydantic.v1` import and catching an `ImportError` exception. 

This is still a work in progress and maybe we might consider just sticking with pydantic 1 for now.