### PR TITLE
Migrate tests for "new" HTF features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,6 @@ name: "CI"
 on:
   pull_request:
     branches:
-      - main
-      - htf-migration
   push:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - htf-migration
   push:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,171 @@
+# custom ignores
+.duecredit.p
+.xxrun
+.idea/
+.vscode/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*~
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+_version.py
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/reference/api/generated
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# vim
+*.swp
+
+# vscode
+.vscode/
+
+# Rever
+rever/
+

--- a/feflow/tests/conftest.py
+++ b/feflow/tests/conftest.py
@@ -136,7 +136,7 @@ def production_settings(short_settings):
 
 # Mappings fixtures
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def mapping_benzene_toluene(benzene, toluene):
     """Mapping from toluene to benzene"""
     mapping_toluene_to_benzene = {0: 4, 1: 5, 2: 6, 3: 7, 4: 8, 5: 9, 6: 10, 7: 11, 8: 12, 9: 13, 11: 14}

--- a/feflow/tests/conftest.py
+++ b/feflow/tests/conftest.py
@@ -6,7 +6,7 @@ from rdkit import Chem
 from gufe.mapping import LigandAtomMapping
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def gufe_data_dir():
     path = files("gufe.tests.data")
     return path

--- a/feflow/tests/conftest.py
+++ b/feflow/tests/conftest.py
@@ -12,7 +12,7 @@ def gufe_data_dir():
     return path
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def benzene_modifications(gufe_data_dir):
     source = gufe_data_dir.joinpath("benzene_modifications.sdf")
     with as_file(source) as f:
@@ -29,12 +29,12 @@ def solvent_comp():
     yield gufe.SolventComponent(positive_ion="Na", negative_ion="Cl")
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def benzene(benzene_modifications):
     return gufe.SmallMoleculeComponent(benzene_modifications["benzene"])
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def toluene(benzene_modifications):
     return gufe.SmallMoleculeComponent(benzene_modifications["toluene"])
 

--- a/feflow/tests/test_hybrid_topology.py
+++ b/feflow/tests/test_hybrid_topology.py
@@ -205,7 +205,7 @@ class TestHTFVirtualSites:
 
         for mol in [benz_off, tol_off]:
             tip4p_system_generator.create_system(
-                mol.to_openmm(), molecules=[mol]
+                mol.to_topology().to_openmm(), molecules=[mol]
             )
 
         # Create state A model & get relevant OpenMM objects
@@ -223,7 +223,7 @@ class TestHTFVirtualSites:
 
         # Now for state B
         tol_topology, tol_alchem_resids = topologyhelpers.combined_topology(
-            benz_topology, tol_off.to_openmm(),
+            benz_topology, tol_off.to_topology().to_openmm(),
             exclude_resids=comp_resids[benzene]
         )
 

--- a/feflow/tests/test_hybrid_topology.py
+++ b/feflow/tests/test_hybrid_topology.py
@@ -284,7 +284,7 @@ class TestHTFVirtualSites:
 
         assert num_waters == len(virtual_sites)
 
-    def test_tip4p_check_vsite_parameters(tip4p_benzene_to_toluene_htf):
+    def test_tip4p_check_vsite_parameters(self, tip4p_benzene_to_toluene_htf):
 
         htf = tip4p_benzene_to_toluene_htf
 

--- a/feflow/tests/test_hybrid_topology.py
+++ b/feflow/tests/test_hybrid_topology.py
@@ -8,6 +8,7 @@ import pytest
 from feflow.utils.hybrid_topology import HybridTopologyFactory
 from feflow.tests.utils import extract_htf_data
 
+import mdtraj as mdt
 from openmm import unit as omm_unit
 from openmm.app import NoCutoff, PME
 from openmm import (
@@ -142,6 +143,19 @@ class TestHybridTopologyFactory:
         final_htf_n_atoms = len(htf.final_atom_indices)
         assert initial_htf_n_atoms - final_htf_n_atoms == n_atoms_diff, \
             "Different number of atoms in HTF compared to original molecules."
+
+        # 16 atoms:
+        # 11 common atoms, 1 extra hydrogen in benzene, 4 extra in toluene
+        # 12 bonds in benzene + 4 extra toluene bonds
+        assert len(list(htf.hybrid_topology.atoms)) == 16
+        assert len(list(htf.hybrid_topology.bonds)) == 16
+        # check that the omm_hybrid_topology has the right things
+        assert len(list(htf.omm_hybrid_topology.atoms())) == 16
+        assert len(list(htf.omm_hybrid_topology.bonds())) == 16
+        # check that we can convert back the mdtraj hybrid_topology attribute
+        ret_top = mdt.Topology.to_openmm(htf.hybrid_topology)
+        assert len(list(ret_top.atoms())) == 16
+        assert len(list(ret_top.bonds())) == 16
 
         # TODO: Validate common atoms include 6 carbon atoms
 

--- a/feflow/tests/test_lambdaprotocol.py
+++ b/feflow/tests/test_lambdaprotocol.py
@@ -63,5 +63,5 @@ def test_lambda_schedule(windows):
         functions='default',
         windows=windows
     )
-    assert len(lambdas.lamda_schedule) == windows
+    assert len(lambdas.lambda_schedule) == windows
 

--- a/feflow/tests/test_lambdaprotocol.py
+++ b/feflow/tests/test_lambdaprotocol.py
@@ -50,3 +50,18 @@ def test_lambda_protocol_naked_charges():
                   lambda x: 2.0 * x if x < 0.5 else 1.0}
     with pytest.raises(ValueError):
         lp = lambda_protocol.LambdaProtocol(functions=naked_charge_functions)
+
+
+def test_lambda_schedule_defaults():
+    lambdas = lambda_protocol.LambdaProtocol(functions='default')
+    assert len(lambdas.lambda_schedule) == 10
+
+
+@pytest.mark.parametrize('windows', [11, 6, 9000])
+def test_lambda_schedule(windows):
+    lambdas = lambda_protocol.LambdaProtocol(
+        functions='default',
+        windows=windows
+    )
+    assert len(lambdas.lamda_schedule) == windows
+


### PR DESCRIPTION
This ports:
  - [x] "environment" virtual site tests (i.e. will tip4p-ew work without breaking the HTF)
  - [x] couple of extra lambda protocol tests (mainly just checking that setting the number of windows works)
  - [x] quick test that the omm_topology building works as intended (this used to be broken before)

Also adds a `gitignore` file, seems like it was missing?