### PR TITLE
Initial quick support for pydantic 2 (>=1.10.17)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,11 +23,12 @@ defaults:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}-latest
-    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }}"
+    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }} - pydantic ${{matrix.pydantic}}"
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu"]
+        pydantic: ["1", "2"]
         python-version:
           - "3.10"
           - "3.11"
@@ -52,6 +53,7 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{ matrix.python-version }}
+            pydantic=${{ matrix.pydantic }}
           init-shell: bash
 
       - name: "Install"
@@ -80,7 +82,7 @@ jobs:
           # Set the OFE_SLOW_TESTS to True if running a Cron job
           OFE_SLOW_TESTS: ${{ fromJSON('{"false":"false","true":"true"}')[github.event_name != 'pull_request'] }}
         run: |
-          pytest -n auto -v --cov=feflow --cov-report=xml --durations=10
+              pytest -n auto -v --cov=feflow --cov-report=xml --durations=10
 
       - name: codecov
         if: ${{ github.repository == 'choderalab/feflow'

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openmm
   - openmmforcefields >=0.14.1  # TODO: remove when upstream deps fix this
   - pymbar <4
-  - pydantic=1  # TODO: Modify when we support pydantic 2
+  - pydantic >=1.10.17
   - python
 
     # Testing (optional deps)

--- a/feflow/settings/integrators.py
+++ b/feflow/settings/integrators.py
@@ -6,10 +6,7 @@ would be shared between different integrators, and subclasses of it
 for the specific integrator settings.
 """
 
-try:
-    from pydantic.v1 import validator
-except ImportError:
-    from pydantic import validator  # type: ignore[assignment]
+from pydantic.v1 import validator
 
 from openff.units import unit
 from openff.models.types import FloatQuantity

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -10,7 +10,7 @@ from feflow.settings import (
 )
 
 from gufe.settings import Settings
-from pydantic import root_validator
+from pydantic.v1 import root_validator
 from openfe.protocols.openmm_utils.omm_settings import (
     OpenMMSolvationSettings,
     OpenMMEngineSettings,


### PR DESCRIPTION
Changing the try-error imports and just using `pydantic.v1` API point for now. This should be supporting `pydantic>=1.10.17` as per the migration guide in https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features 

Solves #14 