### PR TITLE
Remove perses references in docs

### DIFF
--- a/feflow/protocols/nonequilibrium_cycling.py
+++ b/feflow/protocols/nonequilibrium_cycling.py
@@ -450,7 +450,7 @@ class CycleUnit(ProtocolUnit):
         ----------
         context: openmm.Context
             Current simulation context where from extract positions.
-        hybrid_topology_factory: perses.annihilation.relative.HybridTopologyFactory
+        hybrid_topology_factory: HybridTopologyFactory
             Hybrid topology factory where to extract positions and mapping information
 
         Returns
@@ -508,7 +508,7 @@ class CycleUnit(ProtocolUnit):
 
         # Setting up logging to file in shared filesystem
         file_logger = logging.getLogger("neq-cycling")
-        output_log_path = ctx.shared / "perses-neq-cycling.log"
+        output_log_path = ctx.shared / "feflow-neq-cycling.log"
         file_handler = logging.FileHandler(output_log_path, mode="w")
         file_handler.setLevel(logging.DEBUG)  # TODO: Set to INFO in production
         log_formatter = logging.Formatter(

--- a/feflow/utils/hybrid_topology.py
+++ b/feflow/utils/hybrid_topology.py
@@ -2551,8 +2551,7 @@ class HybridTopologyFactory:
         The positions are assigned by first copying all the mapped positions
         from the old system in, then copying the
         mapped positions from the new system. This means that there is an
-        assumption that the positions common to old and new are the same
-        (which is the case for perses as-is).
+        assumption that the positions common to old and new are the same.
 
         Returns
         -------


### PR DESCRIPTION
Some unnecessary perses reference still exist in the documentation, minor set of changes to change these.