### PR TITLE
Add ability to defer minimization from SetupUnit to CycleUnit(s)

### DIFF
--- a/feflow/protocols/nonequilibrium_cycling.py
+++ b/feflow/protocols/nonequilibrium_cycling.py
@@ -389,8 +389,9 @@ class SetupUnit(ProtocolUnit):
         context.setPositions(positions)
 
         try:
-            # Minimize
-            openmm.LocalEnergyMinimizer.minimize(context)
+            # Minimize (if not deferred)
+            if not settings.defer_minimization:
+                openmm.LocalEnergyMinimizer.minimize(context)
 
             # SERIALIZE SYSTEM, STATE, INTEGRATOR
             # need to set velocities to temperature so serialized state features velocities,
@@ -506,6 +507,8 @@ class CycleUnit(ProtocolUnit):
         import openmm.unit as openmm_unit
         from openmmtools.integrators import PeriodicNonequilibriumIntegrator
 
+
+
         # Setting up logging to file in shared filesystem
         file_logger = logging.getLogger("neq-cycling")
         output_log_path = ctx.shared / "perses-neq-cycling.log"
@@ -534,6 +537,10 @@ class CycleUnit(ProtocolUnit):
         platform = get_openmm_platform(settings.engine_settings.compute_platform)
         context = openmm.Context(system, integrator, platform)
         context.setState(state)
+
+        # Minimize (if deferred)
+        if settings.defer_minimization:
+            openmm.LocalEnergyMinimizer.minimize(context)
 
         # Equilibrate
         thermodynamic_settings = settings.thermo_settings

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -10,7 +10,7 @@ from feflow.settings import (
 )
 
 from gufe.settings import Settings
-from pydantic import root_validator
+from pydantic import root_validator, Field
 from openfe.protocols.openmm_utils.omm_settings import (
     OpenMMSolvationSettings,
     OpenMMEngineSettings,
@@ -81,6 +81,15 @@ class NonEquilibriumCyclingSettings(Settings):
     atom_selection_expression: str = "not water"  # TODO: no longer used
 
     num_cycles: int = 100  # Number of cycles to run
+
+    # control where to perform energy minimization; used in particular on
+    # Folding@Home to defer energy minimization so it is performed on volunteer
+    # hosts
+    defer_minimization: bool = Field(
+        False,
+        description="If ``True``, perform energy minimization in CycleUnit; if ``False``, perform it in SetupUnit."
+    )
+
 
     @root_validator
     def save_frequencies_consistency(cls, values):


### PR DESCRIPTION
On conventional compute resources, it makes sense to perform energy minimization in the SetupUnit, since there may be many CycleUnits that use those same minimized coordinates as their starting point.

However, uses of this same protocol on unconventional compute, such as Folding@Home, may require minimization to be performed outside of the SetupUnit, and instead in the CycleUnit (the F@H `openmm-core` running on a volunteer host). This is because the host running the SetupUnit is unlikely to have a GPU, but hosts running the dynamics for CycleUnit will, and minimization on a CPU is orders of magnitude slower.

This change introduces a new setting for this protocol, `defer_minimization`, that defaults to `False`, yielding current behavior. When set to `True`, minimization is instead performed in the CycleUnit(s), and not performed in the SetupUnit.
